### PR TITLE
fix: make gitignore relative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Dependencies
-/node_modules
+node_modules
 
 # Production
-/build
+build
 
 # Generated files
 .docusaurus
@@ -19,4 +19,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-/tmp
+tmp


### PR DESCRIPTION
As we use this template in a subfolder in the git repo we have to make all gitignore paths relative.