### PR TITLE
fix: add missing file creation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ module.exports = {
 // empty file is ok
 ```
 
-```
+```js
 // ./docs/versions.json
-// some valid json value is ok
+// empty object is ok
 {}
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ module.exports = {
 // empty file is ok
 ```
 
+```
+// ./docs/versions.json
+// some valid json value is ok
+{}
+```
+
 ## Adding Documentation
 
 Next, put your markdown files in `./docs/docs`. You may also want to add the CircleCI Orb `ory/docs` to your CI config,


### PR DESCRIPTION
As there might be more files necessary in the future (and there are already enough now), shouldn't we just add a Makefile to create them with default values?