### PR TITLE
doc: reference config

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -187,6 +187,11 @@ flag: \`${config.projectSlug} --config path/to/config.yaml\`.
 Config files can be formatted as JSON, YAML and TOML. Some configuration values support reloading without server restart.
 All configuration values can be set using environment variables, as documented below.
 
+This reference configuration documents all keys, also deprecated ones! 
+It is a reference for all possible configuration values.
+
+If you are looking for an example configuration, it is better to try out the quickstart.
+
 To find out more about edge cases like setting string array values through environmental variables head to the
 [Configuring ORY services](https://www.ory.sh/docs/ecosystem/configuring) section.
 


### PR DESCRIPTION
Added short explanation why there is so many deprecated keys in the reference.