### PR TITLE
feat: allow fields to force show the env var block

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -87,7 +87,8 @@ const enhance = (schema, parents = []) => (item) => {
     })
   }
 
-  if (!hasChildren) {
+  const showEnvVarBlockForObject = pathOr('', [...path, 'showEnvVarBlockForObject'], schema)
+  if (!hasChildren || showEnvVarBlockForObject) {
     const env = [...parents, key].map((i) => i.toUpperCase()).join('_')
     comments.push(
       ' Set this value using environment variables on',
@@ -97,6 +98,11 @@ const enhance = (schema, parents = []) => (item) => {
       `    > set ${env}=<value>`,
       ''
     )
+
+    // Show this if the config property is an object, to call out how to specify the env var
+    if (hasChildren) {
+      comments.push(' This can be set as an environment variable by supplying it as a JSON object.', '')
+    }
   }
 
   item.commentBefore = comments.join('\n')
@@ -187,7 +193,7 @@ flag: \`${config.projectSlug} --config path/to/config.yaml\`.
 Config files can be formatted as JSON, YAML and TOML. Some configuration values support reloading without server restart.
 All configuration values can be set using environment variables, as documented below.
 
-This reference configuration documents all keys, also deprecated ones! 
+This reference configuration documents all keys, also deprecated ones!
 It is a reference for all possible configuration values.
 
 If you are looking for an example configuration, it is better to try out the quickstart.

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -87,7 +87,11 @@ const enhance = (schema, parents = []) => (item) => {
     })
   }
 
-  const showEnvVarBlockForObject = pathOr('', [...path, 'showEnvVarBlockForObject'], schema)
+  const showEnvVarBlockForObject = pathOr(
+    '',
+    [...path, 'showEnvVarBlockForObject'],
+    schema
+  )
   if (!hasChildren || showEnvVarBlockForObject) {
     const env = [...parents, key].map((i) => i.toUpperCase()).join('_')
     comments.push(
@@ -101,7 +105,10 @@ const enhance = (schema, parents = []) => (item) => {
 
     // Show this if the config property is an object, to call out how to specify the env var
     if (hasChildren) {
-      comments.push(' This can be set as an environment variable by supplying it as a JSON object.', '')
+      comments.push(
+        ' This can be set as an environment variable by supplying it as a JSON object.',
+        ''
+      )
     }
   }
 


### PR DESCRIPTION
If the field is an object, also show an extra line about how to set it with json.
@zepatrik  re: https://github.com/ory/kratos/pull/833