### PR TITLE
fix: deterministic jsf output and formatting in gen scripts

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -5,12 +5,15 @@ const YAML = require('yaml')
 const { pathOr } = require('ramda')
 const path = require('path')
 const fs = require('fs')
+const prettier = require('prettier')
+const prettierStyles = require('ory-prettier-styles')
 
 jsf.option({
   alwaysFakeOptionals: true,
   useExamplesValue: true,
   useDefaultValue: true,
-  minItems: 1
+  minItems: 1,
+  random: () => 0
 })
 
 if (process.argv.length !== 3 || process.argv[1] === 'help') {
@@ -215,7 +218,7 @@ ${out.yaml}
     return new Promise((resolve, reject) => {
       fs.writeFile(
         path.resolve(config.updateConfig.dst),
-        content,
+        prettier.format(content, { ...prettierStyles, parser: 'markdown' }),
         'utf8',
         (err) => {
           if (err) {

--- a/scripts/fix-api.js
+++ b/scripts/fix-api.js
@@ -1,4 +1,6 @@
 const fs = require('fs')
+const prettier = require('prettier')
+const prettierStyles = require('ory-prettier-styles')
 
 if (process.argv.length !== 3 || process.argv[1] === 'help') {
   console.error(`
@@ -41,9 +43,13 @@ fs.readFile(file, (err, b) => {
     // .replace(/^> Body parameter/gim, '### Request body',-1)
     .replace(/^> ([0-9]+) Response$/gim, '###### $1 response', -1)
 
-  fs.writeFile(file, t, (err) => {
-    if (err) {
-      throw err
+  fs.writeFile(
+    file,
+    prettier.format(t, { ...prettierStyles, parser: 'mdx' }),
+    (err) => {
+      if (err) {
+        throw err
+      }
     }
-  })
+  )
 })


### PR DESCRIPTION
Makes the JSON Schema Faker deterministic by always providing the same random seed. Also, generated files from `fix-api.js` and `config.js` are now automatically formatted using prettier.
This should reduce diff size after running `npm run gen` significantly.