### PR TITLE
fix: swagger api.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "gen": "npm run widdershins && cd .. && node ./docs/scripts/fix-api.js ./docs/docs/reference/api.mdx && node ./docs/scripts/config.js docs/config.js && node ./docs/scripts/gen-faq.js",
     "docusaurus": "docusaurus",
-    "widdershins": "widdershins -u .widdershins/templates -e .widdershins/config.json ../.schema/api.swagger.json -o ./docs/reference/api.mdx",
+    "widdershins": "widdershins -u .widdershins/templates -e .widdershins/config.json ../spec/api.json -o ./docs/reference/api.mdx",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
The path of `/schema/api.swagger.json` has been changed to `/spec/api.json`.
This fixes the `npm run gen` command with the correct path.