### PR TITLE
docs: fix discussions url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,7 +23,7 @@ const links = [
     position: 'left'
   },
   {
-    href: 'https://github.com/ory/${githubRepoName}/discussions',
+    href: `https://github.com/ory/${githubRepoName}/discussions`,
     label: 'Discussions',
     position: 'left'
   },


### PR DESCRIPTION
## Proposed changes

Currently the link to discussions in multiple ory docs is broken. Visiting https://www.ory.sh/kratos/docs/ and clicking the discussions link in the header leads to https://github.com/ory/${githubRepoName}/discussions

The source of this bug is https://github.com/ory/docusaurus-template/blob/master/docusaurus.config.js#L26

Clearly, the presence of ${githubRepoName} gives us the clue that the string should have been a template literal. This is not the case, because quotation marks have been instead of backticks. 

This PR only changes the single quotation marks to backticks.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

This has already been discussed here: https://github.com/ory/kratos/pull/1226
