### PR TITLE
feat: highlight explanation of config reference

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -205,10 +205,14 @@ flag: \`${config.projectSlug} --config path/to/config.yaml\`.
 Config files can be formatted as JSON, YAML and TOML. Some configuration values support reloading without server restart.
 All configuration values can be set using environment variables, as documented below.
 
+:::warning Disclaimer
+
 This reference configuration documents all keys, also deprecated ones!
 It is a reference for all possible configuration values.
 
 If you are looking for an example configuration, it is better to try out the quickstart.
+
+:::
 
 To find out more about edge cases like setting string array values through environmental variables head to the
 [Configuring ORY services](https://www.ory.sh/docs/ecosystem/configuring) section.


### PR DESCRIPTION
Maybe people will finally read that part after this change :sweat_smile: 

https://ory-community.slack.com/archives/C012RBZFMDG/p1627029071095300

Example of how it will look like:

![Screenshot from 2021-07-23 11-04-09](https://user-images.githubusercontent.com/5354445/126760715-66ef9d4f-acdc-461f-9ebf-f0225cc6b0f4.png)
