### PR TITLE
chore: Use module-aware go list in scripts/config.js

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -11,7 +11,7 @@ const { execSync } = require('child_process')
 const fetch = require('node-fetch')
 
 const oryXVersion = execSync(
-  "cd ..; go list -f '{{.Module.Version}}' -find github.com/ory/x"
+  "cd ..; go list -f '{{.Version}}' -m github.com/ory/x"
 )
   .toString('utf-8')
   .trim()


### PR DESCRIPTION
As per some discussion from https://github.com/ory/oathkeeper/pull/838

> The issue is that the existing go list without a -m flag isn't module aware, when it tries to list the packages this way the following happens:
> ```
> $ go list -f '{{.Module.Version}}' github.com/ory/x
> package github.com/ory/x: build constraints exclude all Go files in /Users/tobbbles/code/go/pkg/mod/github.com/ory/x@v0.0.165
>```
> This appears to be due to github.com/ory/x not containing any Go files in the root, so go list doesn't deem it a valid package.
> This was previously solved by just touching a go package in the ory/x root on a 'patch' branch; but IMO the issue is this incorrect listing from go list not resolving the module version, but trying to resolve the used package version