### PR TITLE
fix: match route `reference/rest-api` for redoc style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "docusaurus-template",
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "2.0.0-beta.6",

--- a/src/theme/API.module.css
+++ b/src/theme/API.module.css
@@ -1,13 +1,19 @@
+:global #route-identifier[data-route*='reference/rest-api'] .container,
 :global #route-identifier[data-route*='reference/api'] .container {
   width: 100% !important;
   max-width: 100% !important;
 }
 
+:global #route-identifier[data-route*='reference/rest-api'] .container .col,
 :global #route-identifier[data-route*='reference/api'] .container .col {
   width: 100% !important;
   max-width: 100% !important;
 }
 
+:global
+  #route-identifier[data-route*='reference/rest-api']
+  .container
+  .col.col--3,
 :global #route-identifier[data-route*='reference/api'] .container .col.col--3 {
   display: none;
 }


### PR DESCRIPTION
closes https://github.com/ory/keto/issues/752

The Keto REST API is under a different path than for the other projects, as there is two APIs (REST & gRPC).