### PR TITLE
fix: background of zoomed diagrams (#82)

### DIFF
--- a/src/theme/mermaid.module.css
+++ b/src/theme/mermaid.module.css
@@ -23,6 +23,7 @@
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.1);
   z-index: 10000;
+  margin-bottom: 0;
 }
 
 .graph.overlay .backdrop {
@@ -34,6 +35,7 @@
   background-color: white;
   text-align: center;
   cursor: default;
+  overflow: auto;
 }
 
 .graph.overlay .backdrop svg {


### PR DESCRIPTION
Solves #82 ,

Example with Ory Kratos:
![1](https://user-images.githubusercontent.com/44102335/140784687-0a2e3df1-6053-4b60-9ad1-9c601c2686a0.png)

Solution after:
![image](https://user-images.githubusercontent.com/44102335/140784845-df86af56-e610-45f2-a0e0-116baa3f4140.png)
