### PR TITLE
chore: use ory/web consent banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -188,6 +188,7 @@ module.exports = {
       }
     ],
     '@docusaurus/plugin-content-pages',
+    require.resolve('./src/plugins/ory-scripts-loader'),
     require.resolve('./src/plugins/docusaurus-plugin-matamo'),
     '@docusaurus/plugin-sitemap'
   ],

--- a/src/plugins/ory-scripts-loader/index.js
+++ b/src/plugins/ory-scripts-loader/index.js
@@ -1,0 +1,11 @@
+const path = require('path')
+
+module.exports = function (context) {
+  return {
+    name: 'docusaurus-plugin-ory-web-script',
+
+    getClientModules() {
+      return [path.resolve(__dirname, './ory-scripts-loader')]
+    }
+  }
+}

--- a/src/plugins/ory-scripts-loader/ory-scripts-loader.js
+++ b/src/plugins/ory-scripts-loader/ory-scripts-loader.js
@@ -1,0 +1,23 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment'
+
+export default (function () {
+  if (
+    !ExecutionEnvironment.canUseDOM ||
+    process.env.NODE_ENV !== 'production'
+  ) {
+    return null
+  }
+
+  const script = document.createElement('script')
+  script.src = 'https://www.ory.sh/scripts.js'
+  script.onload = () => window.initAnalytics()
+  document.body.appendChild(script)
+
+  return {
+    onRouteUpdate() {
+      if (window && typeof window.initAnalytics === 'function') {
+        window.initAnalytics()
+      }
+    }
+  }
+})()

--- a/src/plugins/ory-scripts-loader/package.json
+++ b/src/plugins/ory-scripts-loader/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.js"
+}


### PR DESCRIPTION
This PR aims at using the `http://www.ory.sh/scripts.js` (added in https://github.com/ory/web/pull/501) to integrate the cookie consent banner in a consistent way.
