### PR TITLE
fix: avoid tracking page view on hash change

### DIFF
--- a/src/plugins/docusaurus-plugin-matamo/analytics.js
+++ b/src/plugins/docusaurus-plugin-matamo/analytics.js
@@ -12,6 +12,7 @@ export default (function () {
     return null
   }
 
+  let lastLocation = window.location.pathname
   return {
     onRouteUpdate({ location }) {
       if (!window._paq) {
@@ -21,6 +22,11 @@ export default (function () {
       const pagePath = location
         ? location.pathname + location.search + location.hash
         : undefined
+
+      if (lastLocation === location.pathname) {
+        return
+      }
+      lastLocation = location.pathname
 
       _paq.push(['setCustomUrl', pagePath])
       _paq.push(['setDocumentTitle', document.domain + '/' + document.title])


### PR DESCRIPTION
Attempt to correct the behavior of analytics to avoid counting "in-page" / "anchor" navigation (mostly happening when clicking the links of the table of content on the right side of the page).

