### PR TITLE
fix: prevent analytics script to load outside of prod

### DIFF
--- a/src/plugins/ory-scripts-loader/index.js
+++ b/src/plugins/ory-scripts-loader/index.js
@@ -6,6 +6,8 @@ module.exports = function (context) {
 
     // https://docusaurus.io/docs/api/plugin-methods/lifecycle-apis#injectHtmlTags
     injectHtmlTags({ content }) {
+      if (process.env.NODE_ENV !== 'production') return {}
+
       return {
         postBodyTags: [
           '<script src="https://www.ory.sh/scripts.js" async></script>'


### PR DESCRIPTION
Possible cause of strange metrics could be that `https://www.ory.sh/scripts.js` is always loaded.

This PR adds a "environment check" to only load the script in production.

Related to https://github.com/ory-corp/general/issues/482